### PR TITLE
feature: Add drain_key_if and remove_key_if

### DIFF
--- a/src/exhaust.rs
+++ b/src/exhaust.rs
@@ -1,0 +1,36 @@
+pub(crate) struct ExhaustIter<I>
+where
+    I: Iterator,
+{
+    inner: I,
+}
+
+impl<I> ExhaustIter<I>
+where
+    I: Iterator,
+{
+    pub fn new(inner: I) -> Self {
+        Self { inner }
+    }
+}
+
+impl<I> Iterator for ExhaustIter<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<I> Drop for ExhaustIter<I>
+where
+    I: Iterator,
+{
+    fn drop(&mut self) {
+        // Exhaust the remaining elements
+        for _ in &mut self.inner {}
+    }
+}

--- a/src/exhaust.rs
+++ b/src/exhaust.rs
@@ -20,6 +20,7 @@ where
 {
     type Item = I::Item;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@
 mod map;
 
 pub use map::*;
+pub(crate) mod exhaust;


### PR DESCRIPTION
Thank you for the excellent crate. It's a perfect fit for what I wanted.

I added two functions `drain_key_if` and `remove_key_if` that I needed.

In making those work I also added an `ExhaustIter` behind the scenes that consumes an iterator even when it's dropped prematurely. Perhaps that's controversial. If you don't want that, let me know and I'll take it out.

Thank you for the crate!